### PR TITLE
travis: Test versions 1.10 and up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.9
-  - "1.10"
+  - 1.10.x
+  - 1.11.x
   - master
 
 matrix:


### PR DESCRIPTION
As one of the deps is using 'strings.Build' and it's only availablee on 1.10 and up