### PR TITLE
Added: Logger to the packages

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -3,9 +3,12 @@ package cmd
 import (
 	"errors"
 	"fmt"
+	"io"
+	"net"
 	"net/http"
 	"os"
 	"path"
+	"strconv"
 
 	"github.com/boltdb/bolt"
 	kitlog "github.com/go-kit/kit/log"
@@ -86,7 +89,39 @@ var (
 
 			mux.Handle("/", storing.MakeHandler(s))
 
-			http.Handle("/", handlers.LoggingHandler(os.Stdout, mux))
+			http.Handle("/", handlers.CustomLoggingHandler(os.Stdout, mux, func(writer io.Writer, params handlers.LogFormatterParams) {
+				username := "-"
+				if params.URL.User != nil {
+					if name := params.URL.User.Username(); name != "" {
+						username = name
+					}
+				}
+
+				host, _, err := net.SplitHostPort(params.Request.RemoteAddr)
+				if err != nil {
+					host = params.Request.RemoteAddr
+				}
+
+				uri := params.Request.RequestURI
+
+				// Requests using the CONNECT method over HTTP/2.0 must use
+				// the authority field (aka r.Host) to identify the target.
+				// Refer: https://httpwg.github.io/specs/rfc7540.html#CONNECT
+				if params.Request.ProtoMajor == 2 && params.Request.Method == "CONNECT" {
+					uri = params.Request.Host
+				}
+				if uri == "" {
+					uri = params.URL.RequestURI()
+				}
+				logger.Log(
+					"host", host,
+					"username", username,
+					"method", params.Request.Method,
+					"uri", uri,
+					"status", strconv.Itoa(params.StatusCode),
+					"size", strconv.Itoa(params.Size),
+				)
+			}))
 
 			return http.ListenAndServe(fmt.Sprintf(":%d", cfg.Port), nil)
 		},
@@ -111,7 +146,7 @@ func init() {
 	serveCmd.PersistentFlags().StringP("remote", "r", "", "The URL of a remote Node to join on the cluster")
 	viper.BindPFlag("remote", serveCmd.PersistentFlags().Lookup("remote"))
 
-	serveCmd.PersistentFlags().IntP("replica", "rep", 2, "The default number of replicas used if none specified on the requests")
+	serveCmd.PersistentFlags().Int("replica", 2, "The default number of replicas used if none specified on the requests")
 	viper.BindPFlag("replica", serveCmd.PersistentFlags().Lookup("replica"))
 
 	serveCmd.PersistentFlags().String("memberlist-bind-port", "", "The port is used for both UDP and TCP gossip. By default a free port will be used")

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -8,6 +8,7 @@ import (
 	"path"
 
 	"github.com/boltdb/bolt"
+	kitlog "github.com/go-kit/kit/log"
 	"github.com/gorilla/handlers"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
@@ -30,6 +31,8 @@ var (
 			if err != nil {
 				return err
 			}
+			logger := kitlog.NewLogfmtLogger(kitlog.NewSyncWriter(os.Stdout))
+			logger = kitlog.With(logger, "ts", kitlog.DefaultTimestampUTC, "caller", kitlog.DefaultCaller)
 
 			if len(cfg.Volumes) == 0 {
 				return errors.New("at last one volume is required")
@@ -72,7 +75,7 @@ var (
 				vs = append(vs, v)
 			}
 
-			m, err := membership.New(cfg, vs, cfg.Remote)
+			m, err := membership.New(cfg, vs, cfg.Remote, logger)
 			if err != nil {
 				return err
 			}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -80,7 +80,7 @@ var (
 				return err
 			}
 
-			s := storing.New(cfg, m)
+			s := storing.New(cfg, m, logger)
 
 			mux := http.NewServeMux()
 

--- a/integration/helper_test.go
+++ b/integration/helper_test.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"testing"
 
+	kitlog "github.com/go-kit/kit/log"
+
 	"github.com/boltdb/bolt"
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/require"
@@ -79,7 +81,10 @@ func newClient(t *testing.T, name string, remote string) (*client.Client, string
 		Remote:             remote,
 	}
 
-	m, err := membership.New(cfg, []volume.Local{v}, cfg.Remote)
+	logger := kitlog.NewLogfmtLogger(kitlog.NewSyncWriter(os.Stdout))
+	logger = kitlog.With(logger, "ts", kitlog.DefaultTimestampUTC, "caller", kitlog.DefaultCaller)
+
+	m, err := membership.New(cfg, []volume.Local{v}, cfg.Remote, logger)
 	require.NoError(t, err)
 
 	s := storing.New(cfg, m)

--- a/integration/helper_test.go
+++ b/integration/helper_test.go
@@ -87,7 +87,7 @@ func newClient(t *testing.T, name string, remote string) (*client.Client, string
 	m, err := membership.New(cfg, []volume.Local{v}, cfg.Remote, logger)
 	require.NoError(t, err)
 
-	s := storing.New(cfg, m)
+	s := storing.New(cfg, m, logger)
 	h := storing.MakeHandler(s)
 
 	server.Config.Handler = h

--- a/membership/event_delegate.go
+++ b/membership/event_delegate.go
@@ -28,7 +28,8 @@ func (e *eventDelegate) NotifyJoin(n *memberlist.Node) {
 		panic(err)
 	}
 
-	c, err := client.New(net.JoinHostPort(n.Addr.String(), strconv.Itoa(meta.Port)))
+	url := net.JoinHostPort(n.Addr.String(), strconv.Itoa(meta.Port))
+	c, err := client.New(url)
 	if err != nil {
 		panic(err)
 	}
@@ -40,6 +41,7 @@ func (e *eventDelegate) NotifyJoin(n *memberlist.Node) {
 
 	e.members.nodesLock.Lock()
 	e.members.nodes[n.Name] = nn
+	e.members.logger.Log("action", "join", "name", n.Name, "url", url)
 	e.members.nodesLock.Unlock()
 }
 
@@ -50,6 +52,7 @@ func (e *eventDelegate) NotifyLeave(n *memberlist.Node) {
 	nn := e.members.nodes[n.Name]
 	e.members.removedVolumeIDs = append(e.members.removedVolumeIDs, nn.meta.VolumeIDs...)
 	delete(e.members.nodes, n.Name)
+	e.members.logger.Log("action", "leave", "name", n.Name)
 
 	e.members.nodesLock.Unlock()
 	e.members.removedVolumeIDsLock.Unlock()

--- a/membership/membership.go
+++ b/membership/membership.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"sync"
 
+	kitlog "github.com/go-kit/kit/log"
 	"github.com/hashicorp/memberlist"
 	"github.com/xescugc/rebost/client"
 	"github.com/xescugc/rebost/config"
@@ -34,6 +35,8 @@ type Membership struct {
 	// nodes leaving the cluster
 	removedVolumeIDs     []string
 	removedVolumeIDsLock sync.Mutex
+
+	logger kitlog.Logger
 }
 
 // node represents a Node in the cluseter, with the metadata (meta)
@@ -44,12 +47,13 @@ type node struct {
 }
 
 // New returns an implementation of the Membership interface
-func New(cfg *config.Config, lv []volume.Local, remote string) (*Membership, error) {
+func New(cfg *config.Config, lv []volume.Local, remote string, logger kitlog.Logger) (*Membership, error) {
 	m := &Membership{
 		localVolumes:     lv,
 		nodes:            make(map[string]node),
 		cfg:              cfg,
 		removedVolumeIDs: make([]string, 0),
+		logger:           logger,
 	}
 
 	list, err := memberlist.Create(m.buildConfig(cfg))

--- a/membership/membership.go
+++ b/membership/membership.go
@@ -53,7 +53,7 @@ func New(cfg *config.Config, lv []volume.Local, remote string, logger kitlog.Log
 		nodes:            make(map[string]node),
 		cfg:              cfg,
 		removedVolumeIDs: make([]string, 0),
-		logger:           logger,
+		logger:           kitlog.With(logger, "src", "membership"),
 	}
 
 	list, err := memberlist.Create(m.buildConfig(cfg))

--- a/membership/membership_test.go
+++ b/membership/membership_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	kitlog "github.com/go-kit/kit/log"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,7 +26,7 @@ func TestVolumes(t *testing.T) {
 		p, err := util.FreePort()
 		require.NoError(t, err)
 
-		m, err := membership.New(&config.Config{MemberlistBindPort: p}, []volume.Local{v}, "")
+		m, err := membership.New(&config.Config{MemberlistBindPort: p}, []volume.Local{v}, "", kitlog.NewNopLogger())
 		require.NoError(t, err)
 		assert.Len(t, m.Nodes(), 0)
 		assert.Equal(t, []volume.Local{v}, m.LocalVolumes())
@@ -43,7 +44,7 @@ func TestVolumes(t *testing.T) {
 			p2, err := util.FreePort()
 			require.NoError(t, err)
 			cfg2 := &config.Config{MemberlistName: "am2", Replica: -1, MemberlistBindPort: p2}
-			m2, err := membership.New(cfg2, []volume.Local{v2}, "")
+			m2, err := membership.New(cfg2, []volume.Local{v2}, "", kitlog.NewNopLogger())
 			require.NoError(t, err)
 
 			s := storing.New(cfg2, m2)
@@ -53,7 +54,7 @@ func TestVolumes(t *testing.T) {
 			p3, err := util.FreePort()
 			require.NoError(t, err)
 			cfg := &config.Config{MemberlistName: "am", MemberlistBindPort: p3}
-			m, err := membership.New(cfg, []volume.Local{v}, server.URL)
+			m, err := membership.New(cfg, []volume.Local{v}, server.URL, kitlog.NewNopLogger())
 			require.NoError(t, err)
 			assert.Len(t, m.Nodes(), 1)
 			assert.Equal(t, []volume.Local{v}, m.LocalVolumes())
@@ -70,7 +71,7 @@ func TestVolumes(t *testing.T) {
 			p2, err := util.FreePort()
 			require.NoError(t, err)
 			cfg2 := &config.Config{MemberlistName: "rm2", Replica: -1, MemberlistBindPort: p2}
-			m2, err := membership.New(cfg2, []volume.Local{v2}, "")
+			m2, err := membership.New(cfg2, []volume.Local{v2}, "", kitlog.NewNopLogger())
 			require.NoError(t, err)
 			s := storing.New(cfg2, m2)
 			server := httptest.NewServer(storing.MakeHandler(s))
@@ -79,7 +80,7 @@ func TestVolumes(t *testing.T) {
 			p3, err := util.FreePort()
 			require.NoError(t, err)
 			cfg := &config.Config{MemberlistName: "rm", MemberlistBindPort: p3}
-			m, err := membership.New(cfg, []volume.Local{v}, server.URL)
+			m, err := membership.New(cfg, []volume.Local{v}, server.URL, kitlog.NewNopLogger())
 			require.NoError(t, err)
 			assert.Len(t, m.Nodes(), 1)
 			assert.Equal(t, []volume.Local{v}, m.LocalVolumes())

--- a/membership/membership_test.go
+++ b/membership/membership_test.go
@@ -47,7 +47,7 @@ func TestVolumes(t *testing.T) {
 			m2, err := membership.New(cfg2, []volume.Local{v2}, "", kitlog.NewNopLogger())
 			require.NoError(t, err)
 
-			s := storing.New(cfg2, m2)
+			s := storing.New(cfg2, m2, kitlog.NewNopLogger())
 			server := httptest.NewServer(storing.MakeHandler(s))
 			defer server.Close()
 
@@ -73,7 +73,7 @@ func TestVolumes(t *testing.T) {
 			cfg2 := &config.Config{MemberlistName: "rm2", Replica: -1, MemberlistBindPort: p2}
 			m2, err := membership.New(cfg2, []volume.Local{v2}, "", kitlog.NewNopLogger())
 			require.NoError(t, err)
-			s := storing.New(cfg2, m2)
+			s := storing.New(cfg2, m2, kitlog.NewNopLogger())
 			server := httptest.NewServer(storing.MakeHandler(s))
 			defer server.Close()
 

--- a/storing/service.go
+++ b/storing/service.go
@@ -53,7 +53,7 @@ func New(cfg *config.Config, m Membership, logger kitlog.Logger) Service {
 		ctx:    ctx,
 		cancel: cancel,
 
-		logger: logger,
+		logger: kitlog.With(logger, "src", "storing"),
 	}
 
 	if s.cfg.Replica != -1 {

--- a/storing/service.go
+++ b/storing/service.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	kitlog "github.com/go-kit/kit/log"
 	"github.com/xescugc/rebost/config"
 	"github.com/xescugc/rebost/volume"
 )
@@ -37,11 +38,13 @@ type service struct {
 
 	ctx    context.Context
 	cancel context.CancelFunc
+
+	logger kitlog.Logger
 }
 
 // New returns an implementation of the Node with
 // the given parameters
-func New(cfg *config.Config, m Membership) Service {
+func New(cfg *config.Config, m Membership, logger kitlog.Logger) Service {
 	ctx, cancel := context.WithCancel(context.Background())
 	s := &service{
 		members: m,
@@ -49,6 +52,8 @@ func New(cfg *config.Config, m Membership) Service {
 
 		ctx:    ctx,
 		cancel: cancel,
+
+		logger: logger,
 	}
 
 	if s.cfg.Replica != -1 {

--- a/storing/service_test.go
+++ b/storing/service_test.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"testing"
 
+	kitlog "github.com/go-kit/kit/log"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -34,7 +35,7 @@ func TestCreateFile(t *testing.T) {
 
 		m.EXPECT().LocalVolumes().Return([]volume.Local{v})
 
-		s := storing.New(&config.Config{Replica: -1}, m)
+		s := storing.New(&config.Config{Replica: -1}, m, kitlog.NewNopLogger())
 
 		err := s.CreateFile(ctx, key, buff, rep)
 		require.NoError(t, err)
@@ -62,7 +63,7 @@ func TestCreateFile(t *testing.T) {
 		v.EXPECT().NextReplica(gomock.Any()).Return(nil, errors.New("not found")).AnyTimes()
 		m.EXPECT().RemovedVolumeIDs().Return(nil).AnyTimes()
 
-		s := storing.New(&config.Config{Replica: rep}, m)
+		s := storing.New(&config.Config{Replica: rep}, m, kitlog.NewNopLogger())
 
 		err := s.CreateFile(ctx, key, buff, 0)
 		require.NoError(t, err)
@@ -89,7 +90,7 @@ func TestGetFile(t *testing.T) {
 		v.EXPECT().HasFile(gomock.Any(), key).Return(true, nil)
 		v.EXPECT().GetFile(gomock.Any(), key).Return(ioutil.NopCloser(bytes.NewBufferString("expectedcontent")), nil)
 
-		s := storing.New(&config.Config{Replica: -1}, m)
+		s := storing.New(&config.Config{Replica: -1}, m, kitlog.NewNopLogger())
 		ior, err := s.GetFile(ctx, key)
 
 		require.NoError(t, err)
@@ -115,7 +116,7 @@ func TestGetFile(t *testing.T) {
 		s2.EXPECT().HasFile(gomock.Any(), key).Return(true, nil)
 		s2.EXPECT().GetFile(gomock.Any(), key).Return(ioutil.NopCloser(bytes.NewBufferString("expectedcontent")), nil)
 
-		s := storing.New(&config.Config{Replica: -1}, m)
+		s := storing.New(&config.Config{Replica: -1}, m, kitlog.NewNopLogger())
 
 		ior, err := s.GetFile(ctx, key)
 		require.NoError(t, err)
@@ -141,7 +142,7 @@ func TestDeleteFile(t *testing.T) {
 		v.EXPECT().HasFile(gomock.Any(), key).Return(true, nil)
 		v.EXPECT().DeleteFile(gomock.Any(), key).Return(nil)
 
-		s := storing.New(&config.Config{Replica: -1}, m)
+		s := storing.New(&config.Config{Replica: -1}, m, kitlog.NewNopLogger())
 
 		err := s.DeleteFile(ctx, key)
 		require.NoError(t, err)
@@ -164,7 +165,7 @@ func TestDeleteFile(t *testing.T) {
 		s2.EXPECT().HasFile(gomock.Any(), key).Return(true, nil)
 		s2.EXPECT().DeleteFile(gomock.Any(), key).Return(nil)
 
-		s := storing.New(&config.Config{Replica: -1}, m)
+		s := storing.New(&config.Config{Replica: -1}, m, kitlog.NewNopLogger())
 
 		err := s.DeleteFile(ctx, key)
 		require.NoError(t, err)
@@ -186,7 +187,7 @@ func TestHasFile(t *testing.T) {
 
 		v.EXPECT().HasFile(gomock.Any(), key).Return(true, nil)
 
-		s := storing.New(&config.Config{Replica: -1}, m)
+		s := storing.New(&config.Config{Replica: -1}, m, kitlog.NewNopLogger())
 
 		ok, err := s.HasFile(ctx, key)
 		require.NoError(t, err)
@@ -212,7 +213,7 @@ func TestHasFile(t *testing.T) {
 		v.EXPECT().HasFile(gomock.Any(), key).Return(false, nil).AnyTimes()
 		v2.EXPECT().HasFile(gomock.Any(), key).Return(true, nil)
 
-		s := storing.New(&config.Config{Replica: -1}, m)
+		s := storing.New(&config.Config{Replica: -1}, m, kitlog.NewNopLogger())
 
 		ok, err := s.HasFile(ctx, key)
 		require.NoError(t, err)
@@ -232,7 +233,7 @@ func TestHasFile(t *testing.T) {
 
 		v.EXPECT().HasFile(gomock.Any(), key).Return(false, nil)
 
-		s := storing.New(&config.Config{Replica: -1}, m)
+		s := storing.New(&config.Config{Replica: -1}, m, kitlog.NewNopLogger())
 
 		ok, err := s.HasFile(ctx, key)
 		require.NoError(t, err)
@@ -250,7 +251,7 @@ func TestConfig(t *testing.T) {
 		m := mock.NewMembership(ctrl)
 		defer ctrl.Finish()
 
-		s := storing.New(&expcfg, m)
+		s := storing.New(&expcfg, m, kitlog.NewNopLogger())
 
 		cfg, err := s.Config(ctx)
 		require.NoError(t, err)
@@ -284,7 +285,7 @@ func TestCreateReplica(t *testing.T) {
 
 		v.EXPECT().ID().Return(createdToVolID)
 
-		s := storing.New(&config.Config{}, m)
+		s := storing.New(&config.Config{}, m, kitlog.NewNopLogger())
 
 		volID, err := s.CreateReplica(ctx, key, buff)
 		require.NoError(t, err)
@@ -301,7 +302,7 @@ func TestCreateReplica(t *testing.T) {
 		m := mock.NewMembership(ctrl)
 		defer ctrl.Finish()
 
-		s := storing.New(&config.Config{Replica: -1}, m)
+		s := storing.New(&config.Config{Replica: -1}, m, kitlog.NewNopLogger())
 
 		volID, err := s.CreateReplica(ctx, key, buff)
 		assert.EqualError(t, err, "can not store replicas")
@@ -334,7 +335,7 @@ func TestUpdateFileReplica(t *testing.T) {
 		v.EXPECT().NextReplica(gomock.Any()).Return(nil, errors.New("not found")).AnyTimes()
 		m.EXPECT().RemovedVolumeIDs().Return(nil).AnyTimes()
 
-		s := storing.New(&config.Config{}, m)
+		s := storing.New(&config.Config{}, m, kitlog.NewNopLogger())
 
 		err := s.UpdateFileReplica(ctx, key, vids, rep)
 		require.NoError(t, err)
@@ -351,7 +352,7 @@ func TestUpdateFileReplica(t *testing.T) {
 		m := mock.NewMembership(ctrl)
 		defer ctrl.Finish()
 
-		s := storing.New(&config.Config{Replica: -1}, m)
+		s := storing.New(&config.Config{Replica: -1}, m, kitlog.NewNopLogger())
 
 		err := s.UpdateFileReplica(ctx, key, vids, rep)
 		assert.EqualError(t, err, "can not store replicas")


### PR DESCRIPTION
First implementation of the logger to the packages.

* cmd: Add logger for the http requests
* membership: Add it to log the async actions that may happen (leave,join)
* storing: Add it to log the async actions related to replicas.