### PR TITLE
Added cache for objects on volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Cache(LRU) to the logic to fetch an object form another node so we don't have to search for it again once we found it once [Issue#35](https://github.com/xescugc/rebost/issues/35)
+
 ## Updated
 
 - Migrated from 'boltdb/bolt' to 'go.etcd.io/bbolt' and also updated all the dependencies [Issue#10](https://github.com/xescugc/rebost/issues/10)

--- a/client/client.go
+++ b/client/client.go
@@ -181,24 +181,25 @@ type hasFileRequest struct {
 }
 
 type hasFileResponse struct {
-	Ok  bool
-	Err string `json:"error,omitempty"`
+	Ok       bool
+	VolumeID string
+	Err      string `json:"error,omitempty"`
 }
 
 // HasFile returns if the file exists
-func (c Client) HasFile(ctx context.Context, key string) (bool, error) {
+func (c Client) HasFile(ctx context.Context, key string) (string, bool, error) {
 	response, err := c.hasFile(ctx, hasFileRequest{Key: key})
 	if err != nil {
-		return false, err
+		return "", false, err
 	}
 
 	resp := response.(hasFileResponse)
 
 	if resp.Err != "" {
-		return false, errors.New(resp.Err)
+		return "", false, errors.New(resp.Err)
 	}
 
-	return resp.Ok, nil
+	return resp.VolumeID, resp.Ok, nil
 }
 
 type deleteFileRequest struct {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -122,20 +122,22 @@ func TestHasFile(t *testing.T) {
 		var (
 			key  = "fileName"
 			ctrl = gomock.NewController(t)
+			evid = "vid"
 		)
 		st := mock.NewStoring(ctrl)
 		defer ctrl.Finish()
 
-		st.EXPECT().HasFile(gomock.Any(), key).Return(true, nil)
+		st.EXPECT().HasFile(gomock.Any(), key).Return(evid, true, nil)
 
 		h := storing.MakeHandler(st)
 		server := httptest.NewServer(h)
 		c, err := client.New(server.URL)
 		require.NoError(t, err)
 
-		ok, err := c.HasFile(context.Background(), key)
+		vid, ok, err := c.HasFile(context.Background(), key)
 		require.NoError(t, err)
 		assert.True(t, ok)
+		assert.Equal(t, evid, vid)
 	})
 	t.Run("False", func(t *testing.T) {
 		var (
@@ -145,16 +147,17 @@ func TestHasFile(t *testing.T) {
 		st := mock.NewStoring(ctrl)
 		defer ctrl.Finish()
 
-		st.EXPECT().HasFile(gomock.Any(), key).Return(false, nil)
+		st.EXPECT().HasFile(gomock.Any(), key).Return("", false, nil)
 
 		h := storing.MakeHandler(st)
 		server := httptest.NewServer(h)
 		c, err := client.New(server.URL)
 		require.NoError(t, err)
 
-		ok, err := c.HasFile(context.Background(), key)
+		vid, ok, err := c.HasFile(context.Background(), key)
 		require.NoError(t, err)
 		assert.False(t, ok)
+		assert.Equal(t, "", vid)
 	})
 	t.Run("Error", func(t *testing.T) {
 		var (
@@ -164,16 +167,17 @@ func TestHasFile(t *testing.T) {
 		st := mock.NewStoring(ctrl)
 		defer ctrl.Finish()
 
-		st.EXPECT().HasFile(gomock.Any(), key).Return(false, errors.New("some error"))
+		st.EXPECT().HasFile(gomock.Any(), key).Return("", false, errors.New("some error"))
 
 		h := storing.MakeHandler(st)
 		server := httptest.NewServer(h)
 		c, err := client.New(server.URL)
 		require.NoError(t, err)
 
-		ok, err := c.HasFile(context.Background(), key)
+		vid, ok, err := c.HasFile(context.Background(), key)
 		require.NoError(t, err)
 		assert.False(t, ok)
+		assert.Equal(t, "", vid)
 	})
 }
 

--- a/client/transport.go
+++ b/client/transport.go
@@ -8,6 +8,8 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/xescugc/rebost/storing/model"
 )
 
 func encodeHasFileRequest(_ context.Context, r *http.Request, request interface{}) error {
@@ -20,7 +22,8 @@ func decodeHasFileResponse(_ context.Context, r *http.Response) (interface{}, er
 	// As it's a HEAD request it's not possible to return an error on the body
 	// so we directly add this
 	return hasFileResponse{
-		Ok: r.StatusCode == http.StatusNoContent,
+		Ok:       r.StatusCode == http.StatusNoContent,
+		VolumeID: r.Header.Get(model.HasFileVolumeIDHeader),
 	}, nil
 }
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -89,7 +89,10 @@ var (
 				return err
 			}
 
-			s := storing.New(cfg, m, logger)
+			s, err := storing.New(cfg, m, logger)
+			if err != nil {
+				return err
+			}
 
 			mux := http.NewServeMux()
 
@@ -208,6 +211,9 @@ func init() {
 
 	serveCmd.PersistentFlags().Bool("dashboard.enabled", true, "Enable or not the Dashboard on this node")
 	viper.BindPFlag("dashboard.enabled", serveCmd.PersistentFlags().Lookup("dashboard.enabled"))
+
+	serveCmd.PersistentFlags().Int("cache.size", config.DefaultCacheSize, "Size of the cache used to store reference to object location on other nodes")
+	viper.BindPFlag("cache.size", serveCmd.PersistentFlags().Lookup("cache.size"))
 
 	RootCmd.AddCommand(serveCmd)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -13,6 +13,9 @@ const (
 	// if none is defined
 	DefaultReplica = 3
 
+	// DefaultCacheSize is the default size of the cache
+	DefaultCacheSize = 200
+
 	// defaultNameLen is the default length of the
 	// auto generated Node name if none defined
 	defaultNameLen = 7
@@ -40,6 +43,8 @@ type Config struct {
 	// Name is the name the Node will have inside of the Memberlist
 	Name string `mapstructure:"name"`
 
+	Cache Cache
+
 	Memberlist Memberlist
 
 	Dashboard Dashboard
@@ -55,6 +60,11 @@ type Memberlist struct {
 type Dashboard struct {
 	Port    int  `mapstructure:"port"`
 	Enabled bool `mapstructure:"enabled"`
+}
+
+// Cache is the configuration required for the cache
+type Cache struct {
+	Size int `mapstructure:"size"`
 }
 
 // New returns a new Config from the viper.Viper, the ENV variables

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
+	github.com/hashicorp/golang-lru/v2 v2.0.1
 	github.com/hashicorp/memberlist v0.5.0
 	github.com/satori/go.uuid v1.2.0
 	github.com/spf13/afero v1.9.4

--- a/go.sum
+++ b/go.sum
@@ -172,6 +172,8 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.1 h1:5pv5N1lT1fjLg2VQ5KWc7kmucp2x/kvFOnxuVTqZ6x4=
+github.com/hashicorp/golang-lru/v2 v2.0.1/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/memberlist v0.5.0 h1:EtYPN8DpAURiapus508I4n9CzHs2W+8NZGbmmR/prTM=

--- a/integration/helper_test.go
+++ b/integration/helper_test.go
@@ -27,9 +27,9 @@ import (
 
 // newClient initializes a new client.Client with a random Port and random MemberlistBindPort with the
 // given name and remote to connect to.
-// It returns the clien.Client, the URL of the server the client it's connected to and a cancelFn that
+// It returns the clien.Client, the URL of the server the client it's connected to, the volume ID  and a cancelFn that
 // cleans the server.
-func newClient(t *testing.T, name string, remote string) (*client.Client, string, cancelFn) {
+func newClient(t *testing.T, name string, remote string) (*client.Client, string, string, cancelFn) {
 	port, err := util.FreePort()
 	require.NoError(t, err)
 
@@ -98,7 +98,7 @@ func newClient(t *testing.T, name string, remote string) (*client.Client, string
 	cl, err := client.New(u)
 	require.NoError(t, err)
 
-	return cl, u, func() {
+	return cl, u, v.ID(), func() {
 		m.Leave()
 		bdb.Close()
 		os.RemoveAll(tmpDir)

--- a/integration/helper_test.go
+++ b/integration/helper_test.go
@@ -80,6 +80,7 @@ func newClient(t *testing.T, name string, remote string) (*client.Client, string
 			Port: mbp,
 		},
 		Remote: remote,
+		Cache:  config.Cache{Size: config.DefaultCacheSize},
 	}
 
 	logger := kitlog.NewLogfmtLogger(kitlog.NewSyncWriter(os.Stdout))
@@ -88,7 +89,9 @@ func newClient(t *testing.T, name string, remote string) (*client.Client, string
 	m, err := membership.New(cfg, []volume.Local{v}, cfg.Remote, logger)
 	require.NoError(t, err)
 
-	s := storing.New(cfg, m, logger)
+	s, err := storing.New(cfg, m, logger)
+	require.NoError(t, err)
+
 	h := storing.MakeHandler(s)
 
 	server.Config.Handler = h

--- a/integration/integration_test.go
+++ b/integration/integration_test.go
@@ -105,6 +105,9 @@ func TestCRUD(t *testing.T) {
 				txtb, err := io.ReadAll(txtiorc)
 				require.NoError(t, err)
 				txtiorc.Close()
+				vid, _, err := c.HasFile(ctx, keytxt)
+				require.NoError(t, err)
+				assert.NotEmpty(t, vid)
 
 				assert.Equal(t, txtcontent, txtb)
 
@@ -113,6 +116,9 @@ func TestCRUD(t *testing.T) {
 				imgb, err := io.ReadAll(imgiorc)
 				require.NoError(t, err)
 				imgiorc.Close()
+				vid, _, err = c.HasFile(ctx, keyimg)
+				require.NoError(t, err)
+				assert.NotEmpty(t, vid)
 
 				assert.Equal(t, imgcontent, imgb)
 			})

--- a/membership/membership.go
+++ b/membership/membership.go
@@ -18,7 +18,7 @@ import (
 )
 
 // Membership handles all the logic of the Node
-// persistentce and also the localVolumes
+// persistence and also the localVolumes
 type Membership struct {
 	members *memberlist.Memberlist
 	events  *memberlist.EventDelegate
@@ -39,7 +39,7 @@ type Membership struct {
 	logger kitlog.Logger
 }
 
-// node represents a Node in the cluseter, with the metadata (meta)
+// node represents a Node in the cluster, with the metadata (meta)
 // and the connection (conn) to it
 type node struct {
 	conn storing.Service
@@ -132,7 +132,7 @@ func (m *Membership) Nodes() (res []storing.Service) {
 }
 
 // RemovedVolumeIDs returns the list of removed VolumeIDs from
-// the cluser.
+// the cluster.
 // WARNING: Each call to it empties the list so the list
 // of nodes have to be stored/used once called
 func (m *Membership) RemovedVolumeIDs() []string {

--- a/membership/membership_test.go
+++ b/membership/membership_test.go
@@ -26,7 +26,7 @@ func TestVolumes(t *testing.T) {
 		p, err := util.FreePort()
 		require.NoError(t, err)
 
-		m, err := membership.New(&config.Config{Memberlist: config.Memberlist{Port: p}}, []volume.Local{v}, "", kitlog.NewNopLogger())
+		m, err := membership.New(&config.Config{Memberlist: config.Memberlist{Port: p}, Cache: config.Cache{Size: config.DefaultCacheSize}}, []volume.Local{v}, "", kitlog.NewNopLogger())
 		require.NoError(t, err)
 		assert.Len(t, m.Nodes(), 0)
 		assert.Equal(t, []volume.Local{v}, m.LocalVolumes())
@@ -43,17 +43,18 @@ func TestVolumes(t *testing.T) {
 			v2.EXPECT().ID().Return("id")
 			p2, err := util.FreePort()
 			require.NoError(t, err)
-			cfg2 := &config.Config{Name: "am2", Replica: -1, Memberlist: config.Memberlist{Port: p2}}
+			cfg2 := &config.Config{Name: "am2", Replica: -1, Memberlist: config.Memberlist{Port: p2}, Cache: config.Cache{Size: config.DefaultCacheSize}}
 			m2, err := membership.New(cfg2, []volume.Local{v2}, "", kitlog.NewNopLogger())
 			require.NoError(t, err)
 
-			s := storing.New(cfg2, m2, kitlog.NewNopLogger())
+			s, err := storing.New(cfg2, m2, kitlog.NewNopLogger())
+			require.NoError(t, err)
 			server := httptest.NewServer(storing.MakeHandler(s))
 			defer server.Close()
 
 			p3, err := util.FreePort()
 			require.NoError(t, err)
-			cfg := &config.Config{Name: "am", Memberlist: config.Memberlist{Port: p3}}
+			cfg := &config.Config{Name: "am", Memberlist: config.Memberlist{Port: p3}, Cache: config.Cache{Size: config.DefaultCacheSize}}
 			m, err := membership.New(cfg, []volume.Local{v}, server.URL, kitlog.NewNopLogger())
 			require.NoError(t, err)
 			assert.Len(t, m.Nodes(), 1)
@@ -70,16 +71,17 @@ func TestVolumes(t *testing.T) {
 			v2.EXPECT().ID().Return("id2")
 			p2, err := util.FreePort()
 			require.NoError(t, err)
-			cfg2 := &config.Config{Name: "rm2", Replica: -1, Memberlist: config.Memberlist{Port: p2}}
+			cfg2 := &config.Config{Name: "rm2", Replica: -1, Memberlist: config.Memberlist{Port: p2}, Cache: config.Cache{Size: config.DefaultCacheSize}}
 			m2, err := membership.New(cfg2, []volume.Local{v2}, "", kitlog.NewNopLogger())
 			require.NoError(t, err)
-			s := storing.New(cfg2, m2, kitlog.NewNopLogger())
+			s, err := storing.New(cfg2, m2, kitlog.NewNopLogger())
+			require.NoError(t, err)
 			server := httptest.NewServer(storing.MakeHandler(s))
 			defer server.Close()
 
 			p3, err := util.FreePort()
 			require.NoError(t, err)
-			cfg := &config.Config{Name: "rm", Memberlist: config.Memberlist{Port: p3}}
+			cfg := &config.Config{Name: "rm", Memberlist: config.Memberlist{Port: p3}, Cache: config.Cache{Size: config.DefaultCacheSize}}
 			m, err := membership.New(cfg, []volume.Local{v}, server.URL, kitlog.NewNopLogger())
 			require.NoError(t, err)
 			assert.Len(t, m.Nodes(), 1)

--- a/mock/fs.go
+++ b/mock/fs.go
@@ -5,7 +5,7 @@
 package mock
 
 import (
-	"os"
+	fs "io/fs"
 	reflect "reflect"
 	time "time"
 
@@ -37,7 +37,7 @@ func (m *Fs) EXPECT() *FsMockRecorder {
 }
 
 // Chmod mocks base method.
-func (m *Fs) Chmod(arg0 string, arg1 os.FileMode) error {
+func (m *Fs) Chmod(arg0 string, arg1 fs.FileMode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Chmod", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -94,7 +94,7 @@ func (mr *FsMockRecorder) Create(arg0 interface{}) *gomock.Call {
 }
 
 // Mkdir mocks base method.
-func (m *Fs) Mkdir(arg0 string, arg1 os.FileMode) error {
+func (m *Fs) Mkdir(arg0 string, arg1 fs.FileMode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Mkdir", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -108,7 +108,7 @@ func (mr *FsMockRecorder) Mkdir(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // MkdirAll mocks base method.
-func (m *Fs) MkdirAll(arg0 string, arg1 os.FileMode) error {
+func (m *Fs) MkdirAll(arg0 string, arg1 fs.FileMode) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MkdirAll", arg0, arg1)
 	ret0, _ := ret[0].(error)
@@ -151,7 +151,7 @@ func (mr *FsMockRecorder) Open(arg0 interface{}) *gomock.Call {
 }
 
 // OpenFile mocks base method.
-func (m *Fs) OpenFile(arg0 string, arg1 int, arg2 os.FileMode) (afero.File, error) {
+func (m *Fs) OpenFile(arg0 string, arg1 int, arg2 fs.FileMode) (afero.File, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "OpenFile", arg0, arg1, arg2)
 	ret0, _ := ret[0].(afero.File)
@@ -208,10 +208,10 @@ func (mr *FsMockRecorder) Rename(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // Stat mocks base method.
-func (m *Fs) Stat(arg0 string) (os.FileInfo, error) {
+func (m *Fs) Stat(arg0 string) (fs.FileInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Stat", arg0)
-	ret0, _ := ret[0].(os.FileInfo)
+	ret0, _ := ret[0].(fs.FileInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/mock/storing.go
+++ b/mock/storing.go
@@ -110,12 +110,13 @@ func (mr *StoringMockRecorder) GetFile(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // HasFile mocks base method.
-func (m *Storing) HasFile(arg0 context.Context, arg1 string) (bool, error) {
+func (m *Storing) HasFile(arg0 context.Context, arg1 string) (string, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasFile", arg0, arg1)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // HasFile indicates an expected call of HasFile.

--- a/mock/volume.go
+++ b/mock/volume.go
@@ -79,12 +79,13 @@ func (mr *VolumeMockRecorder) GetFile(arg0, arg1 interface{}) *gomock.Call {
 }
 
 // HasFile mocks base method.
-func (m *Volume) HasFile(arg0 context.Context, arg1 string) (bool, error) {
+func (m *Volume) HasFile(arg0 context.Context, arg1 string) (string, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasFile", arg0, arg1)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // HasFile indicates an expected call of HasFile.

--- a/mock/volume_local.go
+++ b/mock/volume_local.go
@@ -94,12 +94,13 @@ func (mr *VolumeLocalMockRecorder) GetFile(arg0, arg1 interface{}) *gomock.Call 
 }
 
 // HasFile mocks base method.
-func (m *VolumeLocal) HasFile(arg0 context.Context, arg1 string) (bool, error) {
+func (m *VolumeLocal) HasFile(arg0 context.Context, arg1 string) (string, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "HasFile", arg0, arg1)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(bool)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // HasFile indicates an expected call of HasFile.

--- a/storing/endpoint.go
+++ b/storing/endpoint.go
@@ -70,17 +70,18 @@ type hasFileRequest struct {
 }
 
 type hasFileResponse struct {
-	Ok bool
+	Ok       bool
+	VolumeID string
 }
 
 func makeHasFileEndpoint(s Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(hasFileRequest)
-		ok, err := s.HasFile(ctx, req.Key)
+		vid, ok, err := s.HasFile(ctx, req.Key)
 		if err != nil {
 			return nil, err
 		}
-		return hasFileResponse{Ok: ok}, nil
+		return hasFileResponse{VolumeID: vid, Ok: ok}, nil
 	}
 }
 

--- a/storing/model/has_file.go
+++ b/storing/model/has_file.go
@@ -1,5 +1,6 @@
 package model
 
 const (
+	// HasFileVolumeIDHeader defines the HEADER used to send the ID of the Volume back
 	HasFileVolumeIDHeader = "X-Rebost-VolumeID"
 )

--- a/storing/model/has_file.go
+++ b/storing/model/has_file.go
@@ -1,0 +1,5 @@
+package model
+
+const (
+	HasFileVolumeIDHeader = "X-Rebost-VolumeID"
+)

--- a/storing/replica.go
+++ b/storing/replica.go
@@ -23,7 +23,7 @@ func (s *service) loopVolumesReplicas() {
 					continue
 				}
 				for _, n := range s.members.Nodes() {
-					ok, err := n.HasFile(s.ctx, rp.Key)
+					_, ok, err := n.HasFile(s.ctx, rp.Key)
 					if err != nil {
 						s.logger.Log("msg", err.Error())
 						continue

--- a/storing/service_test.go
+++ b/storing/service_test.go
@@ -35,9 +35,10 @@ func TestCreateFile(t *testing.T) {
 
 		m.EXPECT().LocalVolumes().Return([]volume.Local{v})
 
-		s := storing.New(&config.Config{Replica: -1}, m, kitlog.NewNopLogger())
+		s, err := storing.New(&config.Config{Replica: -1, Cache: config.Cache{Size: config.DefaultCacheSize}}, m, kitlog.NewNopLogger())
+		require.NoError(t, err)
 
-		err := s.CreateFile(ctx, key, buff, rep)
+		err = s.CreateFile(ctx, key, buff, rep)
 		require.NoError(t, err)
 	})
 	t.Run("SuccessWithConfigReplica", func(t *testing.T) {
@@ -63,9 +64,10 @@ func TestCreateFile(t *testing.T) {
 		v.EXPECT().NextReplica(gomock.Any()).Return(nil, errors.New("not found")).AnyTimes()
 		m.EXPECT().RemovedVolumeIDs().Return(nil).AnyTimes()
 
-		s := storing.New(&config.Config{Replica: rep}, m, kitlog.NewNopLogger())
+		s, err := storing.New(&config.Config{Replica: rep, Cache: config.Cache{Size: config.DefaultCacheSize}}, m, kitlog.NewNopLogger())
+		require.NoError(t, err)
 
-		err := s.CreateFile(ctx, key, buff, 0)
+		err = s.CreateFile(ctx, key, buff, 0)
 		require.NoError(t, err)
 	})
 	t.Run("SuccessMultiVolume", func(t *testing.T) {
@@ -91,7 +93,9 @@ func TestGetFile(t *testing.T) {
 		v.EXPECT().HasFile(gomock.Any(), key).Return(vid, true, nil)
 		v.EXPECT().GetFile(gomock.Any(), key).Return(io.NopCloser(bytes.NewBufferString("expectedcontent")), nil)
 
-		s := storing.New(&config.Config{Replica: -1}, m, kitlog.NewNopLogger())
+		s, err := storing.New(&config.Config{Replica: -1, Cache: config.Cache{Size: config.DefaultCacheSize}}, m, kitlog.NewNopLogger())
+		require.NoError(t, err)
+
 		ior, err := s.GetFile(ctx, key)
 
 		require.NoError(t, err)
@@ -118,7 +122,8 @@ func TestGetFile(t *testing.T) {
 		s2.EXPECT().HasFile(gomock.Any(), key).Return(vid, true, nil)
 		s2.EXPECT().GetFile(gomock.Any(), key).Return(io.NopCloser(bytes.NewBufferString("expectedcontent")), nil)
 
-		s := storing.New(&config.Config{Replica: -1}, m, kitlog.NewNopLogger())
+		s, err := storing.New(&config.Config{Replica: -1, Cache: config.Cache{Size: config.DefaultCacheSize}}, m, kitlog.NewNopLogger())
+		require.NoError(t, err)
 
 		ior, err := s.GetFile(ctx, key)
 		require.NoError(t, err)
@@ -145,9 +150,10 @@ func TestDeleteFile(t *testing.T) {
 		v.EXPECT().HasFile(gomock.Any(), key).Return(vid, true, nil)
 		v.EXPECT().DeleteFile(gomock.Any(), key).Return(nil)
 
-		s := storing.New(&config.Config{Replica: -1}, m, kitlog.NewNopLogger())
+		s, err := storing.New(&config.Config{Replica: -1, Cache: config.Cache{Size: config.DefaultCacheSize}}, m, kitlog.NewNopLogger())
+		require.NoError(t, err)
 
-		err := s.DeleteFile(ctx, key)
+		err = s.DeleteFile(ctx, key)
 		require.NoError(t, err)
 	})
 	t.Run("SuccessMultiVolume", func(t *testing.T) {
@@ -169,9 +175,10 @@ func TestDeleteFile(t *testing.T) {
 		s2.EXPECT().HasFile(gomock.Any(), key).Return(vid, true, nil)
 		s2.EXPECT().DeleteFile(gomock.Any(), key).Return(nil)
 
-		s := storing.New(&config.Config{Replica: -1}, m, kitlog.NewNopLogger())
+		s, err := storing.New(&config.Config{Replica: -1, Cache: config.Cache{Size: config.DefaultCacheSize}}, m, kitlog.NewNopLogger())
+		require.NoError(t, err)
 
-		err := s.DeleteFile(ctx, key)
+		err = s.DeleteFile(ctx, key)
 		require.NoError(t, err)
 	})
 }
@@ -192,7 +199,8 @@ func TestHasFile(t *testing.T) {
 
 		v.EXPECT().HasFile(gomock.Any(), key).Return(evid, true, nil)
 
-		s := storing.New(&config.Config{Replica: -1}, m, kitlog.NewNopLogger())
+		s, err := storing.New(&config.Config{Replica: -1, Cache: config.Cache{Size: config.DefaultCacheSize}}, m, kitlog.NewNopLogger())
+		require.NoError(t, err)
 
 		vid, ok, err := s.HasFile(ctx, key)
 		require.NoError(t, err)
@@ -220,7 +228,8 @@ func TestHasFile(t *testing.T) {
 		v.EXPECT().HasFile(gomock.Any(), key).Return("", false, nil).AnyTimes()
 		v2.EXPECT().HasFile(gomock.Any(), key).Return(evid, true, nil)
 
-		s := storing.New(&config.Config{Replica: -1}, m, kitlog.NewNopLogger())
+		s, err := storing.New(&config.Config{Replica: -1, Cache: config.Cache{Size: config.DefaultCacheSize}}, m, kitlog.NewNopLogger())
+		require.NoError(t, err)
 
 		vid, ok, err := s.HasFile(ctx, key)
 		require.NoError(t, err)
@@ -241,7 +250,8 @@ func TestHasFile(t *testing.T) {
 
 		v.EXPECT().HasFile(gomock.Any(), key).Return("", false, nil)
 
-		s := storing.New(&config.Config{Replica: -1}, m, kitlog.NewNopLogger())
+		s, err := storing.New(&config.Config{Replica: -1, Cache: config.Cache{Size: config.DefaultCacheSize}}, m, kitlog.NewNopLogger())
+		require.NoError(t, err)
 
 		vid, ok, err := s.HasFile(ctx, key)
 		require.NoError(t, err)
@@ -255,12 +265,13 @@ func TestConfig(t *testing.T) {
 		var (
 			ctrl   = gomock.NewController(t)
 			ctx    = context.Background()
-			expcfg = config.Config{Name: "Pepito", Replica: -1}
+			expcfg = config.Config{Name: "Pepito", Replica: -1, Cache: config.Cache{Size: config.DefaultCacheSize}}
 		)
 		m := mock.NewMembership(ctrl)
 		defer ctrl.Finish()
 
-		s := storing.New(&expcfg, m, kitlog.NewNopLogger())
+		s, err := storing.New(&expcfg, m, kitlog.NewNopLogger())
+		require.NoError(t, err)
 
 		cfg, err := s.Config(ctx)
 		require.NoError(t, err)
@@ -294,7 +305,8 @@ func TestCreateReplica(t *testing.T) {
 
 		v.EXPECT().ID().Return(createdToVolID)
 
-		s := storing.New(&config.Config{}, m, kitlog.NewNopLogger())
+		s, err := storing.New(&config.Config{Cache: config.Cache{Size: config.DefaultCacheSize}}, m, kitlog.NewNopLogger())
+		require.NoError(t, err)
 
 		volID, err := s.CreateReplica(ctx, key, buff)
 		require.NoError(t, err)
@@ -311,7 +323,8 @@ func TestCreateReplica(t *testing.T) {
 		m := mock.NewMembership(ctrl)
 		defer ctrl.Finish()
 
-		s := storing.New(&config.Config{Replica: -1}, m, kitlog.NewNopLogger())
+		s, err := storing.New(&config.Config{Replica: -1, Cache: config.Cache{Size: config.DefaultCacheSize}}, m, kitlog.NewNopLogger())
+		require.NoError(t, err)
 
 		volID, err := s.CreateReplica(ctx, key, buff)
 		assert.EqualError(t, err, "can not store replicas")
@@ -345,9 +358,10 @@ func TestUpdateFileReplica(t *testing.T) {
 		v.EXPECT().NextReplica(gomock.Any()).Return(nil, errors.New("not found")).AnyTimes()
 		m.EXPECT().RemovedVolumeIDs().Return(nil).AnyTimes()
 
-		s := storing.New(&config.Config{}, m, kitlog.NewNopLogger())
+		s, err := storing.New(&config.Config{Cache: config.Cache{Size: config.DefaultCacheSize}}, m, kitlog.NewNopLogger())
+		require.NoError(t, err)
 
-		err := s.UpdateFileReplica(ctx, key, vids, rep)
+		err = s.UpdateFileReplica(ctx, key, vids, rep)
 		require.NoError(t, err)
 	})
 	t.Run("ErrorNoReplica", func(t *testing.T) {
@@ -362,9 +376,10 @@ func TestUpdateFileReplica(t *testing.T) {
 		m := mock.NewMembership(ctrl)
 		defer ctrl.Finish()
 
-		s := storing.New(&config.Config{Replica: -1}, m, kitlog.NewNopLogger())
+		s, err := storing.New(&config.Config{Replica: -1, Cache: config.Cache{Size: config.DefaultCacheSize}}, m, kitlog.NewNopLogger())
+		require.NoError(t, err)
 
-		err := s.UpdateFileReplica(ctx, key, vids, rep)
+		err = s.UpdateFileReplica(ctx, key, vids, rep)
 		assert.EqualError(t, err, "can not store replicas")
 	})
 }

--- a/storing/transport.go
+++ b/storing/transport.go
@@ -173,6 +173,7 @@ func decodeHasFileRequest(_ context.Context, r *http.Request) (interface{}, erro
 
 func encodeHasFileResponse(ctx context.Context, w http.ResponseWriter, response interface{}) error {
 	hfr := response.(hasFileResponse)
+	w.Header().Add(model.HasFileVolumeIDHeader, hfr.VolumeID)
 	if hfr.Ok {
 		w.WriteHeader(http.StatusNoContent)
 	} else {

--- a/storing/transport_test.go
+++ b/storing/transport_test.go
@@ -27,6 +27,7 @@ func TestMakeHandler(t *testing.T) {
 		cfg                  = config.Config{Name: "Pepito"}
 		createReplicaVolmeID = "createReplicaVolmeID"
 		rep                  = 2
+		vid                  = "vid"
 	)
 
 	st := mock.NewStoring(ctrl)
@@ -43,11 +44,11 @@ func TestMakeHandler(t *testing.T) {
 	}).Return(nil).AnyTimes()
 	st.EXPECT().GetFile(gomock.Any(), key).Return(io.NopCloser(bytes.NewBuffer(content)), nil).AnyTimes()
 	st.EXPECT().DeleteFile(gomock.Any(), key).Return(nil).AnyTimes()
-	st.EXPECT().HasFile(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, k string) (bool, error) {
+	st.EXPECT().HasFile(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, k string) (string, bool, error) {
 		if k == key {
-			return true, nil
+			return vid, true, nil
 		}
-		return false, nil
+		return "", false, nil
 	}).AnyTimes()
 	st.EXPECT().Config(gomock.Any()).Return(&cfg, nil)
 	st.EXPECT().CreateReplica(gomock.Any(), key, gomock.Any()).Do(func(_ context.Context, _ string, r io.Reader) {

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -34,8 +34,9 @@ type Volume interface {
 	// GetFile search for the file with the key
 	GetFile(ctx context.Context, key string) (io.ReadCloser, error)
 
-	// HasFile checks if a file with the key exists
-	HasFile(ctx context.Context, key string) (bool, error)
+	// HasFile checks if a file with the key exists and returns the volumeID
+	// of where is it
+	HasFile(ctx context.Context, key string) (string, bool, error)
 
 	// DeleteFile deletes the key, if the key points to a
 	// file with 2 keys, then just the key will be deleted
@@ -384,7 +385,7 @@ func (l *local) DeleteFile(ctx context.Context, key string) error {
 	}, l.idxkeys, l.files, l.fs)
 }
 
-func (l *local) HasFile(ctx context.Context, k string) (bool, error) {
+func (l *local) HasFile(ctx context.Context, k string) (string, bool, error) {
 	err := l.startUnitOfWork(ctx, uow.Read, func(ctx context.Context, uw uow.UnitOfWork) error {
 		_, err := uw.IDXKeys().FindByKey(ctx, k)
 		if err != nil {
@@ -395,12 +396,12 @@ func (l *local) HasFile(ctx context.Context, k string) (bool, error) {
 
 	if err != nil {
 		if err.Error() == "not found" {
-			return false, nil
+			return "", false, nil
 		}
-		return false, err
+		return "", false, err
 	}
 
-	return true, nil
+	return l.id, true, nil
 }
 
 func (l *local) NextReplica(ctx context.Context) (*replica.Replica, error) {

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -35,7 +35,9 @@ type Volume interface {
 	GetFile(ctx context.Context, key string) (io.ReadCloser, error)
 
 	// HasFile checks if a file with the key exists and returns the volumeID
-	// of where is it
+	// of where is it.
+	// It's possible to return a vid but false that means we know which volume
+	// has it but it's not this one
 	HasFile(ctx context.Context, key string) (string, bool, error)
 
 	// DeleteFile deletes the key, if the key points to a

--- a/volume/volume_test.go
+++ b/volume/volume_test.go
@@ -556,9 +556,10 @@ func TestHasFile(t *testing.T) {
 
 		mv.IDXKeys.EXPECT().FindByKey(ctx, key).Return(idxkey.New(key, "not needed"), nil)
 
-		ok, err := mv.V.HasFile(ctx, key)
+		vid, ok, err := mv.V.HasFile(ctx, key)
 		require.NoError(t, err)
 		assert.True(t, ok)
+		assert.Equal(t, mv.V.ID(), vid)
 	})
 	t.Run("NotFound", func(t *testing.T) {
 		var (
@@ -572,9 +573,10 @@ func TestHasFile(t *testing.T) {
 
 		mv.IDXKeys.EXPECT().FindByKey(ctx, key).Return(nil, errors.New("not found"))
 
-		ok, err := mv.V.HasFile(ctx, key)
+		vid, ok, err := mv.V.HasFile(ctx, key)
 		require.NoError(t, err)
 		assert.False(t, ok)
+		assert.Equal(t, "", vid)
 	})
 }
 


### PR DESCRIPTION
So when we did the work to know which node has an object we do not have to do it again, we can just
get the volumeID from the cache and then use the Node it has it to fetch directly

Closes #35 