### PR TITLE
volume: Fix missing if condition on error validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initializing with a volume with size was causing an error
   [PR#52](https://github.com/xescugc/rebost/pull/52)
+- Error check on volume goroutine to recalculate size
+  [PR#53](https://github.com/xescugc/rebost/pull/53)
 
 ## [0.2.0] - 2023-03-11
 

--- a/volume/volume.go
+++ b/volume/volume.go
@@ -205,7 +205,9 @@ func New(root string, files file.Repository, idxkeys idxkey.Repository, idxvolum
 				tk.Stop()
 			case <-tk.C:
 				err = l.calculateSize(ctx, root, ts)
-				l.logger.Log("msg", err.Error())
+				if err != nil {
+					l.logger.Log("msg", err.Error())
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
Was causing a panic as if the err is nil then err.Error() fails