### PR TITLE
membership: sort NodesWithoutVolumeIDs by descending free space

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ data/
 rebost
 rebost.db
 .claude
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Sort replication candidate nodes by descending free space so replicas prefer nodes with the most headroom [Issue#15](https://github.com/xescugc/rebost/issues/15)
+
 - Timing configuration flags grouped under `timing.*` prefix (`--timing.volume-downtime`, `--timing.scrub-interval`, `--timing.replica-check-interval`, `--timing.replica-consistency-interval`). Config struct now has a `Timing` sub-struct. [Issue#129](https://github.com/xescugc/rebost/issues/129)
 
 - Replica reconciliation on startup: clears stale replica queue and rebuilds from file state after a crash [Issue#129](https://github.com/xescugc/rebost/issues/129)

--- a/membership/membership.go
+++ b/membership/membership.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"sort"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -164,9 +165,12 @@ func (m *Membership) Nodes() (res []*client.Client) {
 	return
 }
 
-// NodesWithoutVolumeIDs return all the nodes of the Cluster
-func (m *Membership) NodesWithoutVolumeIDs(vids []string) (res []*client.Client) {
+// NodesWithoutVolumeIDs returns all running nodes that do not hold any of the
+// given volume IDs, sorted by descending total free space so the best-capacity
+// node is tried first during replication.
+func (m *Membership) NodesWithoutVolumeIDs(vids []string) []*client.Client {
 	m.nodesLock.RLock()
+	var candidates []node
 	for _, r := range m.nodes {
 		if r.meta.Status != StatusRunning {
 			continue
@@ -179,12 +183,30 @@ func (m *Membership) NodesWithoutVolumeIDs(vids []string) (res []*client.Client)
 			}
 		}
 		if !found {
-			res = append(res, r.conn)
+			candidates = append(candidates, r)
 		}
 	}
 	m.nodesLock.RUnlock()
 
-	return
+	sort.Slice(candidates, func(i, j int) bool {
+		return nodeFreeSpace(candidates[i]) > nodeFreeSpace(candidates[j])
+	})
+
+	res := make([]*client.Client, len(candidates))
+	for i, c := range candidates {
+		res[i] = c.conn
+	}
+	return res
+}
+
+// nodeFreeSpace returns the total free bytes across all of n's gossip-reported volumes.
+// Nodes with no state yet return 0 and sort last, which is the safe conservative choice.
+func nodeFreeSpace(n node) int {
+	total := 0
+	for _, vs := range n.state.Volumes {
+		total += vs.TotalSize() - vs.UsedSize()
+	}
+	return total
 }
 
 // NodesWithCapacity returns all peer nodes that have at least one volume

--- a/membership/sort_test.go
+++ b/membership/sort_test.go
@@ -1,0 +1,51 @@
+package membership
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/xescugc/rebost/client"
+	"github.com/xescugc/rebost/state"
+)
+
+func TestNodesWithoutVolumeIDsSortedByFreeSpace(t *testing.T) {
+	cA, err := client.New("localhost:1")
+	require.NoError(t, err)
+	cB, err := client.New("localhost:2")
+	require.NoError(t, err)
+	cC, err := client.New("localhost:3")
+	require.NoError(t, err)
+
+	m := &Membership{
+		nodes: map[string]node{
+			"sort-a": {
+				conn: cA,
+				meta: Metadata{Status: StatusRunning, Volumes: map[string]struct{}{}},
+				state: State{Volumes: map[string]state.State{
+					"sort-vol-a": {VolumeTotalSize: 1000, VolumeUsedSize: 900}, // 100 free
+				}},
+			},
+			"sort-b": {
+				conn: cB,
+				meta: Metadata{Status: StatusRunning, Volumes: map[string]struct{}{}},
+				state: State{Volumes: map[string]state.State{
+					"sort-vol-b": {VolumeTotalSize: 1000, VolumeUsedSize: 200}, // 800 free
+				}},
+			},
+			"sort-c": {
+				conn: cC,
+				meta: Metadata{Status: StatusRunning, Volumes: map[string]struct{}{}},
+				state: State{Volumes: map[string]state.State{
+					"sort-vol-c": {VolumeTotalSize: 1000, VolumeUsedSize: 600}, // 400 free
+				}},
+			},
+		},
+	}
+
+	ns := m.NodesWithoutVolumeIDs([]string{})
+	require.Len(t, ns, 3)
+	assert.Equal(t, cB, ns[0], "first: sort-b (800 free)")
+	assert.Equal(t, cC, ns[1], "second: sort-c (400 free)")
+	assert.Equal(t, cA, ns[2], "third: sort-a (100 free)")
+}


### PR DESCRIPTION
Replication candidates are now ordered by total available storage (most free first) so that replicas land on the node with the most headroom rather than whichever node happened to iterate first from the map.

Also adds config.Memberlist.PushPullInterval so tests (and operators) can tune how quickly gossip state syncs between peers.

Related #15 (first criterion: total/used storage)